### PR TITLE
lora path of --lora-dir and restrict access

### DIFF
--- a/scripts/lora_queue.py
+++ b/scripts/lora_queue.py
@@ -202,7 +202,7 @@ class Script(scripts.Script):
             all_prompts += proc.all_prompts
             infotexts += proc.infotexts
 
-        if is_save_grid:
+        if is_save_grid and len(result_images) > 1:
             grid_image = images.image_grid(result_images, rows=1)
             result_images.insert(0, grid_image)
             all_prompts.insert(0, "")

--- a/scripts/lora_queue.py
+++ b/scripts/lora_queue.py
@@ -8,17 +8,28 @@ import gradio as gr
 from modules import sd_samplers, errors, scripts, images, sd_models
 from modules.processing import Processed, process_images
 from modules.shared import state, cmd_opts, opts
+from pathlib import Path
+
+lora_dir = Path(cmd_opts.lora_dir).resolve()
+
+
+def allowed_path(path):
+    return Path(path).resolve().is_relative_to(lora_dir)
+
+
+def get_base_path(is_use_custom_path, custom_path):
+    return lora_dir.joinpath(custom_path) if is_use_custom_path else lora_dir
 
 
 def get_directories(base_path):
+    directories = ["/"]
     try:
-        directories = [d for d in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, d))]
+        if allowed_path(base_path):
+            directories.extend([d for d in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, d))])
     except FileNotFoundError:
-        directories = []
+        pass
     except Exception as e:
         print(e)
-        directories = []
-    directories.insert(0, "/")
     return directories
 
 def read_json_file(file_path):
@@ -31,19 +42,15 @@ def get_lora_prompt(lora_path, json_path):
         with open(json_path, 'r', encoding='utf-8') as file:
             data = json.load(file)
 
-        # Extract the filename without the extension
-        filename = lora_path.rsplit('/', 1)[-1].split('.')[0]
-
         # Extract the required fields from the JSON data
         preferred_weight = data.get("preferred weight", "1")
         activation_text = data.get("activation text", "")
-        metadata = sd_models.read_metadata_from_safetensors(lora_path)
-        alias = metadata.get('ss_output_name', filename)
-         
+
         if opts.lora_preferred_name == "Filename":
-            lora_name = filename
+            lora_name = lora_path.stem
         else:
-            lora_name = alias
+            metadata = sd_models.read_metadata_from_safetensors(lora_path.stem)
+            lora_name = metadata.get('ss_output_name', lora_path.stem)
 
         # Format the prompt string
         output = f"<lora:{lora_name}:{preferred_weight}>, {activation_text},"
@@ -60,35 +67,36 @@ class Script(scripts.Script):
 
     def ui(self, is_img2img):
         def update_dirs(is_use_custom_path, custom_path):
-            base_path = custom_path if is_use_custom_path else cmd_opts.lora_dir
+            base_path = get_base_path(is_use_custom_path, custom_path)
             dirs = get_directories(base_path)
             return gr.CheckboxGroup.update(choices=dirs, value=[])
 
         def show_dir_textbox(enabled, custom_path):
-            all_dirs = get_directories(custom_path if enabled else cmd_opts.lora_dir)
+            all_dirs = get_directories(lora_dir.joinpath(custom_path) if enabled else lora_dir)
             return gr.Textbox.update(visible=enabled), gr.CheckboxGroup.update(choices=all_dirs, value=[])
 
         def get_lora(base_path, directories):
             all_loras = []
 
             for directory in directories:
-                # replace "/" in directories with "."
-                if directory == "/":
-                    directory = "."
-
-                safetensor_files = [f for f in os.listdir(os.path.join(base_path, directory)) if f.endswith('.safetensors')]
+                # if directory is "/" use base_path
+                directory = base_path if directory == "/" else os.path.join(base_path, directory)
+                if not allowed_path(directory):
+                    continue
+                safetensor_files = [f for f in os.listdir(directory) if f.endswith('.safetensors')]
                 all_loras.extend([os.path.splitext(f)[0] for f in safetensor_files])
-            
+
             return all_loras
 
         def update_loras(is_use_custom_path, custom_path, directories):
-            base_path = custom_path if is_use_custom_path else cmd_opts.lora_dir
+            base_path = get_base_path(is_use_custom_path, custom_path)
             all_loras = get_lora(base_path, directories)
             visible = len(all_loras) > 0
-            return gr.CheckboxGroup.update(choices=all_loras, value=all_loras, visible=visible), gr.Button.update(visible=visible), gr.Button.update(visible=visible)
+            return gr.CheckboxGroup.update(choices=all_loras, value=all_loras, visible=visible), gr.Button.update(
+                visible=visible), gr.Button.update(visible=visible)
 
         def select_all_dirs(is_use_custom_path, custom_path):
-            base_path = custom_path if is_use_custom_path else cmd_opts.lora_dir
+            base_path = get_base_path(is_use_custom_path, custom_path)
             all_dirs = get_directories(base_path)
             return gr.CheckboxGroup.update(value=all_dirs)
 
@@ -96,16 +104,17 @@ class Script(scripts.Script):
             return gr.CheckboxGroup.update(value=[])
 
         def select_all_lora(is_use_custom_path, custom_path, directories):
-            base_path = custom_path if is_use_custom_path else cmd_opts.lora_dir
+            base_path = get_base_path(is_use_custom_path, custom_path)
             all_loras = get_lora(base_path, directories)
             return gr.CheckboxGroup.update(value=all_loras)
 
         def deselect_all_lora():
             return gr.CheckboxGroup.update(value=[])
 
-        base_dir_checkbox = gr.Checkbox(label="Use Custom Lora path", value=False, elem_id=self.elem_id("base_dir_checkbox"))
+        base_dir_checkbox = gr.Checkbox(label="Use Custom Lora path", value=False,
+                                        elem_id=self.elem_id("base_dir_checkbox"))
         base_dir_textbox = gr.Textbox(label="Lora directory", visible=False, elem_id=self.elem_id("base_dir_textbox"))
-        base_dir = base_dir_textbox.value if base_dir_checkbox.value else cmd_opts.lora_dir
+        base_dir = base_dir_textbox.value if base_dir_checkbox.value else lora_dir
         all_dirs = get_directories(base_dir)
 
         with gr.Group():
@@ -125,7 +134,7 @@ class Script(scripts.Script):
         checkbox_iterate = gr.Checkbox(label="Use consecutive seed", value=False, elem_id=self.elem_id("checkbox_iterate"))
         checkbox_iterate_batch = gr.Checkbox(label="Use same random seed", value=False, elem_id=self.elem_id("checkbox_iterate_batch"))
         checkbox_save_grid = gr.Checkbox(label="Save grid image", value=True, elem_id=self.elem_id("checkbox_save_grid"))
-        
+
         base_dir_checkbox.change(fn=show_dir_textbox, inputs=[base_dir_checkbox, base_dir_textbox], outputs=[base_dir_textbox, directory_checkboxes])
         base_dir_textbox.change(fn=update_dirs, inputs=[base_dir_checkbox, base_dir_textbox], outputs=[directory_checkboxes])
         directory_checkboxes.change(fn=update_loras, inputs=[base_dir_checkbox, base_dir_textbox, directory_checkboxes], outputs=[lora_checkboxes, select_all_lora_button, deselect_all_lora_button])
@@ -136,24 +145,28 @@ class Script(scripts.Script):
 
         return [base_dir_checkbox, base_dir_textbox, directory_checkboxes, lora_checkboxes, checkbox_iterate, checkbox_iterate_batch, checkbox_save_grid]
 
-    def run(self, p, is_use_custom_path, custom_path , directories, selected_loras, checkbox_iterate, checkbox_iterate_batch, is_save_grid):
+    def run(self, p, is_use_custom_path, custom_path, directories, selected_loras, checkbox_iterate, checkbox_iterate_batch, is_save_grid):
         p.do_not_save_grid = not is_save_grid
 
         job_count = 0
         jobs = []
 
-        base_path = custom_path if is_use_custom_path else cmd_opts.lora_dir
+        base_path = get_base_path(is_use_custom_path, custom_path)
         for directory in directories:
-            safetensor_files = [f for f in os.listdir(os.path.join(base_path, directory)) if f.endswith('.safetensors')]
-            
+            # if directory is "/" use base_path
+            directory = base_path if directory == "/" else base_path.joinpath(directory)
+            if not allowed_path(directory):
+                continue
+            safetensor_files = [f for f in os.listdir(directory) if f.endswith('.safetensors')]
+
             for safetensor_file in safetensor_files:
                 lora_filename = os.path.splitext(safetensor_file)[0]
                 if lora_filename not in selected_loras:
                     continue
-                lora_file_path = os.path.join(base_path, directory, safetensor_file)
+                lora_file_path = directory.joinpath(safetensor_file)
                 json_file = lora_filename + '.json'
-                json_file_path = os.path.join(base_path, directory, json_file)
-                
+                json_file_path = directory.joinpath(json_file)
+
                 if os.path.exists(json_file_path):
                     additional_prompt = get_lora_prompt(lora_file_path, json_file_path)
                 else:


### PR DESCRIPTION
## changes
use `--lora-dir` as `base_dir` and-restrict-access outside
- user only need the enter the relative path of the dir, same behavior as `Extra Network` search bar
otherwise user will have to enter `current+work_dir/path/to/lora/dir/sub/dir`
![image](https://github.com/Yinzo/sd-webui-Lora-queue-helper/assets/40751091/1c95f858-95c6-42f5-9c3c-5ac3c861e725)
- restricting access to outside of --lora-dir otherwise one will be able to browse the directory structure of the entire system, can be considered a security risk
there's also absolutely no reason to access outside of `--lora-dir`

## additional minor change
- don't save grid if only 1 image